### PR TITLE
Avoid changing the default Faraday adapter

### DIFF
--- a/lib/gotenberg.rb
+++ b/lib/gotenberg.rb
@@ -4,8 +4,6 @@ require 'uri'
 require 'faraday'
 require 'faraday/multipart'
 
-Faraday.default_adapter = :net_http
-
 require 'tempfile'
 require_relative "gotenberg/version"
 


### PR DESCRIPTION
This could be seen as "doing app-specific choices" in the library.

We already specify the adapter when creating a connection, so this ought to be possible to skip.