### PR TITLE
Forward options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version:
+          - 3.1
+          - "3.0"
+          - 2.7
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in gotenberg.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
+group :development, :test do
+  gem "rspec", "~> 3.0"
+  gem "webmock"
+  gem "multipart-parser"
+end
 
-gem "rspec", "~> 3.0"
+gem "rake", "~> 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,30 @@
 PATH
   remote: .
   specs:
-    gotenberg-client (0.1.1.4)
-      faraday (~> 2.5.2)
-      faraday-multipart (~> 1.0.4)
+    gotenberg-client (0.1.1.9)
+      faraday
+      faraday-multipart
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.5.0)
-    faraday (2.5.2)
+    faraday (2.7.2)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
-    faraday-net_http (3.0.0)
+    faraday-net_http (3.0.2)
+    hashdiff (1.0.1)
+    multipart-parser (0.1.1)
     multipart-post (2.2.3)
+    public_suffix (5.0.1)
     rake (13.0.6)
+    rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -31,14 +39,20 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby2_keywords (0.0.5)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
   gotenberg-client!
+  multipart-parser
   rake (~> 13.0)
   rspec (~> 3.0)
+  webmock
 
 BUNDLED WITH
    2.2.19

--- a/README.md
+++ b/README.md
@@ -1,27 +1,33 @@
 # Gotenberg client for Ruby
-Gotenberg is awesome, but using it with Ruby is complicated.
-This gem is not intended to wrap the whole api of gotenberg but to make
-the creation of pdf easy in ruby / ruby on rails.
 
-this gem is young and needs a lot of updates and improvements. (work in progress, be patient, or contribute :-) )
+[Gotenberg] is awesome, but using it with Ruby is complicated.
 
-## install
-First download and run gotenberg
+This gem is not intended to wrap the whole api of Gotenberg but to make
+the creation of PDFs easy in Ruby / Ruby on Rails.
+
+This gem is young and needs a lot of updates and improvements. (Work in progress, be patient, or contribute :-) )
+
+## Install
+
+First download and run Gotenberg:
 
 ```
 docker run --rm -p 3000:3000 gotenberg/gotenberg:7
 ```
 
-install gotenberg-client gem
+Install `gotenberg-client` gem
 
 ```
 gem install gotenberg-client
 ```
 
-or add gotenberg-client to your gemfile
+or add `gotenberg-client` to your Gemfile.
 
-## usage
-you will probably use this gem in order to generate pdf in a ruby on rails background task / ruby file. Therefore, this gem do not (yet) integrate any Ruby on Rails tools.
+## Usage
+
+You will probably use this gem to generate PDFs in a Ruby on Rails background job or in a Ruby file.
+
+Therefore, this gem does not (yet) integrate with any Ruby on Rails tools.
 
 ```ruby
 require "gotenberg"
@@ -29,30 +35,29 @@ require "gotenberg"
 api_endpoint = "http://localhost:3000" # change it with your specific port and address.
 gb = Gotenberg::Client.new(api_endpoint)
 
-#check whether your endpoint is working
-gb.up? #true if working
+# check whether your endpoint is working
+gb.up? # true if working
 
 output_pdf = Tempfile.new("my-pdf.pdf")
 html = "<h1> my html </h1>"
-gb.html(html,output_pdf)
+gb.html(html, output_pdf)
 
-#do not forget to destroy your tempfile
+# Do not forget to destroy your tempfile
 output_pdf.close
 output_pdf.unlink
-
 ```
 
-if you want to use rails views, the easiest way is to user "render_to_string" from `ActionController::Base`.
-Let's imagine that you have a /app/views/test.html.erb in your project that use @customer variable.
+If you want to use Rails views, the easiest way is to use [`ActionController::Base#render_to_string`][render_to_string].
+
+Say you have a view file `app/views/test.html.erb` that requires a `@customer` variable.
 
 ```ruby
 gb = Gotenberg::Client.new(api_endpoint)
 
 output_pdf = Tempfile.new("my-pdf.pdf")
-ac = ActionController::Base.new()
-ac.instance_variable_set(:@customer,Customer.find(params[:id]))
-gb.html(ac.render_to_string("/test.html.erb"),output_pdf)
-
+ac = ActionController::Base.new
+ac.instance_variable_set(:@customer, Customer.find(params[:id]))
+gb.html(ac.render_to_string("/test.html.erb"), output_pdf)
 ```
 
 ## Contributing
@@ -64,3 +69,5 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jbd010
 
 do whatever you want with it
 
+[Gotenberg]: https://gotenberg.dev/
+[render_to_string]: https://api.rubyonrails.org/classes/AbstractController/Rendering.html#method-i-render_to_string

--- a/lib/gotenberg.rb
+++ b/lib/gotenberg.rb
@@ -38,16 +38,12 @@ module Gotenberg
   def html(render,output)
       return false unless self.up?
 
-
-      ind_html = Tempfile.new('index.html')
-      ind_html.write(render)
-      ind_html.rewind
       payload = {
         "index.html": Faraday::Multipart::FilePart.new(
-            File.open(ind_html),
-            'text/html',
-            "index.html"
-          )
+          StringIO.new(render),
+          'text/html',
+          "index.html"
+        )
       }
       url= "#{@api_url}/forms/chromium/convert/html"
     begin
@@ -61,8 +57,6 @@ module Gotenberg
       response=""
     end
 
-    ind_html.close
-    ind_html.unlink
     output.write(response.body.force_encoding("utf-8"))
     return true
 

--- a/lib/gotenberg.rb
+++ b/lib/gotenberg.rb
@@ -4,8 +4,6 @@ require 'uri'
 require 'faraday'
 require 'faraday/multipart'
 
-Faraday.default_adapter = :net_http
-
 require 'tempfile'
 require_relative "gotenberg/version"
 

--- a/lib/gotenberg.rb
+++ b/lib/gotenberg.rb
@@ -29,16 +29,19 @@ module Gotenberg
     # @param render [String] HTML to convert
     # @param output [File, Pathname, #write] Output file
     # @return true if everything OK
-    def html(render, output)
+    def html(render, output, **kwargs)
       return false unless up?
 
-      payload = {
+      content = {
         "index.html": Faraday::Multipart::FilePart.new(
           StringIO.new(render),
           'text/html',
           "index.html"
-        )
+        ),
       }
+
+      payload = kwargs.merge(content)
+
       url = "#{@api_url}/forms/chromium/convert/html"
     begin
       conn = Faraday.new(url) do |f|

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,65 @@
+
+RSpec.describe Gotenberg::Client do
+  let (:client) { described_class.new("http://gotenberg.example.com") }
+  before do
+    stub_request(:post, "http://gotenberg.example.com/forms/chromium/convert/html")
+  end
+
+  context "service down" do
+    before do
+      stub_request(:get, "http://gotenberg.example.com/health").to_return(status: 502, body: 'Bad Gateway')
+    end
+
+    describe "#up?" do
+      it "returns false" do
+        client_status = client.up?
+
+        expect(client_status).to eq(false)
+      end
+    end
+
+    describe "#html" do
+      it "returns early without doing a request" do
+        result = client.html("<html />", StringIO.new)
+
+        expect(result).to eq(false)
+        expect(a_request(:post, "http://gotenberg.example.com/forms/chromium/convert/html")).not_to have_been_made
+
+      end
+    end
+  end
+
+  context "service up" do
+    before do
+      stub_request(:get, "http://gotenberg.example.com/health").to_return(status: 200, body: '{"status": "up"}')
+    end
+
+    describe '#up?' do
+      it "returns true if service is up" do
+        client_status = client.up?
+
+        expect(client_status).to eq(true)
+      end
+    end
+
+    describe "#html" do
+      it "does a request" do
+        result = client.html("<html />", StringIO.new)
+
+        expect(result).not_to eq(false)
+        expect(a_request(:post, "http://gotenberg.example.com/forms/chromium/convert/html")).to have_been_made
+      end
+
+      it "forwards options to the API" do
+        result = client.html("<html />", StringIO.new, preferCssPageSize: true)
+
+        expect(WebMock).to have_requested(:post, "http://gotenberg.example.com/forms/chromium/convert/html")
+        .with { |request|
+          parsed_request = parse_multipart_message(request)
+          interesting_part = parsed_request[:parts].find { _1[:part].name == "preferCssPageSize" }
+          expect(interesting_part[:body]).to eq(["true"])
+        }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "gotenberg"
+require "webmock/rspec"
+
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -8,6 +11,8 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  config.include Faraday::Multipart::HelperMethods
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
The Chromium conversions default to US Letter paper. There are also options to change this in https://gotenberg.dev/docs/modules/chromium#routes, but this client doesn't yet allow us to get to them.

Opening this PR to enable discussions and to run the tests in github.